### PR TITLE
Canonizing the plugin name

### DIFF
--- a/documentcloud.php
+++ b/documentcloud.php
@@ -1,13 +1,15 @@
 <?php
 /***
  * Plugin Name: DocumentCloud
- * Description: Embed DocumentCloud resources that won't be eaten by the visual editor
+ * Plugin URI: https://www.documentcloud.org/
+ * Description: Embed DocumentCloud resources in WordPress content.
  * Version: 0.1.1
- * Author: Chris Amico
+ * Authors: Chris Amico, Justin Reese
  * License: GPLv2
 ***/
 /*
-    Copyright 2011 National Public Radio, Inc. 
+    Copyright 2011 National Public Radio, Inc.
+    Copyright 2015 DocumentCloud, Investigative Reporters & Editors
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License, version 2, as 

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -1,8 +1,8 @@
 <?php
 /***
- * Plugin Name: Navis DocumentCloud
- * Description: Embed DocumentCloud documents that won't be eaten by the visual editor
- * Version: 0.1
+ * Plugin Name: DocumentCloud
+ * Description: Embed DocumentCloud resources that won't be eaten by the visual editor
+ * Version: 0.1.1
  * Author: Chris Amico
  * License: GPLv2
 ***/
@@ -23,7 +23,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-class Navis_DocumentCloud {
+class WP_DocumentCloud {
     
     function __construct() {
 
@@ -51,7 +51,7 @@ class Navis_DocumentCloud {
         
     function add_tinymce_plugin($plugin_array) {
         $plugin_array['documentcloud'] = plugins_url(
-            'js/navis-documentcloud-editor-plugin.js', __FILE__);
+            'js/documentcloud-editor-plugin.js', __FILE__);
         return $plugin_array;
     }
     
@@ -242,4 +242,4 @@ class Navis_DocumentCloud {
     }
 }
 
-new Navis_DocumentCloud;
+new WP_DocumentCloud;

--- a/js/documentcloud-editor-plugin.js
+++ b/js/documentcloud-editor-plugin.js
@@ -24,7 +24,7 @@
 
             // Register example button
             ed.addButton('documentcloud', {
-                title : 'Document Cloud',
+                title : 'DocumentCloud',
                 cmd : 'documentcloud',
                 image : url + '/button.png'
             });

--- a/js/documentcloud-editor-plugin.js
+++ b/js/documentcloud-editor-plugin.js
@@ -57,7 +57,7 @@
          */
         getInfo : function() {
             return {
-                longname : 'Navis DocumentCloud Plugin',
+                longname : 'DocumentCloud Plugin',
                 author : 'Chris Amico',
                 authorurl : 'http://stateimpact.npr.org/',
                 infourl : 'http://stateimpact.npr.org/',

--- a/js/window.php
+++ b/js/window.php
@@ -14,7 +14,7 @@ $SITEURL .= $_GET[ 'wpbase' ];
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
     <script src="<?php echo $SITEURL; ?>wp-includes/js/tinymce/tiny_mce_popup.js"></script>
     <script src="<?php echo $SITEURL; ?>wp-includes/js/tinymce/utils/form_utils.js"></script>
-    <script src="<?php echo $SITEURL; ?>wp-content/plugins/navis-documentcloud/js/tinywindow.js?version=1"></script>
+    <script src="<?php echo $SITEURL; ?>wp-content/plugins/wp-documentcloud/js/tinywindow.js?version=1"></script>
     <style>
     form p {
         font-size: 1.5em;

--- a/js/window.php
+++ b/js/window.php
@@ -14,7 +14,7 @@ $SITEURL .= $_GET[ 'wpbase' ];
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
     <script src="<?php echo $SITEURL; ?>wp-includes/js/tinymce/tiny_mce_popup.js"></script>
     <script src="<?php echo $SITEURL; ?>wp-includes/js/tinymce/utils/form_utils.js"></script>
-    <script src="<?php echo $SITEURL; ?>wp-content/plugins/wp-documentcloud/js/tinywindow.js?version=1"></script>
+    <script src="<?php echo $SITEURL; ?>wp-content/plugins/documentcloud/js/tinywindow.js?version=1"></script>
     <style>
     form p {
         font-size: 1.5em;

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Navis DocumentCloud ===
+=== DocumentCloud ===
 Contributors: chrisamico
 Tags: documentcloud, documents
 Requires at least: 3.2
@@ -41,7 +41,7 @@ This will use default height and width settings, which you can update in the Wor
 
 == Installation ==
 
-1. Upload the navis-documentcloud directory to `wp-content/plugins/wordpress-documentcloud`
+1. Upload the wp-documentcloud directory to `wp-content/plugins/wp-documentcloud`
 2. Activate the plugin
 3. In your posts, add documents using the DocumentCloud button, or the `[documentcloud]` shortcode.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,15 +1,15 @@
 === DocumentCloud ===
-Contributors: chrisamico
+Contributors: chrisamico, reefdog
 Tags: documentcloud, documents
 Requires at least: 3.2
 Tested up to: 3.9.1
 Stable tag: trunk
 
-Embed DocumentCloud documents that won't be eaten by the visual editor.
+Embed DocumentCloud resources in WordPress content.
 
 == Description ==
 
-[DocumentCloud](http://www.documentcloud.org/home) is a free service allowing journalists to analyze, annotate and publish documents, funded by the Knight Foundation. Initial development supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
+[DocumentCloud](https://www.documentcloud.org/) is a free service allowing journalists to analyze, annotate and publish documents, funded by the Knight Foundation. Initial development of this plugin supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
 
 DocumentCloud's normal embed code looks like this:
 
@@ -41,7 +41,7 @@ This will use default height and width settings, which you can update in the Wor
 
 == Installation ==
 
-1. Upload the wp-documentcloud directory to `wp-content/plugins/wp-documentcloud`
+1. Upload the documentcloud directory to `wp-content/plugins/documentcloud`
 2. Activate the plugin
 3. In your posts, add documents using the DocumentCloud button, or the `[documentcloud]` shortcode.
 


### PR DESCRIPTION
* Rename "Navis DocumentCloud" to "DocumentCloud"
* Change class to `WP_DocumentCloud`
* Remove "navis" references in filenames/paths (including one backwards-incompatible change to the `tinywindow.js` reference)