### PR TITLE
Generate embed codes through DocumentCloud's oEmbed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ There are many options you can set using shortcode attributes. Some are specific
 - `notes` (boolean): Show/hide notes:
 - `search` (boolean): Hide or show search form.
 - `sidebar` (boolean): Hide or show sidebar. Defaults `false`.
-- `pdf` (boolean): Hide or show link to download original PDF.
-- `text` (boolean): Hide or show text tab.
+- `pdf` (boolean): Hide or show link to download original PDF. Defaults `true`.
+- `text` (boolean): Hide or show text tab. Defaults `true`.
 - `zoom` (boolean): Hide or show zoom slider.
 - `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,30 @@ The DocumentCloud WordPress plugin lets you embed [DocumentCloud](https://www.do
 
 1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
 2. Activate the plugin through the "Plugins" menu
-3. Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud
-4. In your posts, embed documents or notes using the DocumentCloud button or the `[documentcloud]` shortcode
+3. In your posts, embed documents or notes using the DocumentCloud button or the `[documentcloud]` shortcode
+4. Optional: Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud. (This default width will only be used if you set `responsive="false"` on an embed.)
 
 ## Usage
 
-There are many options you can set using shortcode attributes. Some are specific to the type of resource you're embedding.
+This plugin allows you embed DocumentCloud resources using a custom shortcode:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html"]
+
+When you save, WordPress fetches and stores the actual embed code HTML from the DocumentCloud servers using oEmbed. You can freely toggle between visual and HTML mode without mangling embed code, and your embed will always be up to date with the latest embed code.
+
+By default, documents will have a responsive width (it will narrow and widen as necessary to fill available content area) and use the theme's default height. If you want to override this, you can either set `responsive="false"` or explicitly set a `width`:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="600"]
+
+You can set your own defaults in Settings > DocumentCloud, but default widths will be ignored unless `responsive` is disabled:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" responsive="false"]
+
+To embed a note, just use any note-specific URL. Notes ignore `width/height` and always act responsively:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html#document/p1/a53674"]
+
+Here's the full list of embed options you can pass via shortcode attributes; some are specific to the type of resource you're embedding.
 
 ### All resources (documents and notes):
 
@@ -36,32 +54,34 @@ There are many options you can set using shortcode attributes. Some are specific
 - `zoom` (boolean): Hide or show zoom slider.
 - `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
 
-For example, if you want to embed a document at 800px wide, pre-scrolled to page 3:
+You can read more about publishing and embedding DocumentCloud resources on https://www.documentcloud.org/help/publishing.
 
-    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" responsive="false" width="800" default_page="3"]
+## Caching
 
-To embed a note, use any note-specific URL:
+Ideally, when WordPress hits our oEmbed service to fetch the embed code, it would obey the `cache_age` we return. Despite [conversation](https://core.trac.wordpress.org/ticket/14759) around this, it doesn't seem to.
 
-    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html#document/p1/a53674"]
+Instead, it lets us choose between no cache at all (so *every pageload* triggers a call to our oEmbed service to get the embed code) or a supposed 24-hour cache stored in the `postmeta` table. Unfortunately, [our tests](https://github.com/documentcloud/wordpress-documentcloud/issues/20) seem to show this cache is never expired, which means we can choose between no cache (thus possibly DDOSing ourselves) or a permanent cache (thus possibly having stale embed codes). We've chosen the latter; hopefully this cache does eventually expire, and our embed codes shouldn't change that often anyway.
+
+If you find yourself absolutely needing to expire the cache, though, you have two choices:
+
+1. Delete the appropriate `_oembed_*` rows from your `postmeta` table.
+2. Modify the shortcode attributes for the embed, since this is recognized as a new embed by WordPress.
 
 ## Changelog
 
 ### 0.3
-* Added support for embedding notes.
-* Default to responsive
+* Add support for embedding notes.
+* Default to responsive.
+* Enable caching.
 
 ### 0.2
 * Fetch embed code via oEmbed instead of generating statically.
-* Added new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
-* Deprecated `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
+* Add new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
+* Deprecate `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
 
 ### 0.1
 * Initial release.
 
-## History
+## License and History
 
-Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project. Development continued by Justin Reese (@reefdog) at [DocumentCloud](https://www.documentcloud.org/).
-
-## License
-
-The DocumentCloud WordPress plugin is [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html).
+The DocumentCloud WordPress plugin is [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html). Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project. Development continued by Justin Reese (@reefdog) at [DocumentCloud](https://www.documentcloud.org/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# DocumentCloud WordPress plugin
+
+The DocumentCloud WordPress plugin lets you embed [DocumentCloud](https://www.documentcloud.org/) resources into WordPress content using [shortcodes](https://codex.wordpress.org/Shortcode_API).
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html"]
+
+## Installation
+
+1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
+2. Activate the plugin through the "Plugins" menu
+3. Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud
+4. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
+
+## Usage
+
+There are many options you can set using shortcode attributes:
+
+- `url` (**required**, string): Full URL of the DocumentCloud resource.
+- `container` (string): ID of element to insert the document into; if excluded, embedder will create its own container.
+- `height` (integer): Height (in pixels) of the embed.
+- `width` (integer): Width (in pixels) of the embed.
+- `responsive` (boolean): Use responsive layout.
+- `responsive_offset` (integer): Distance (in pixels) to vertically offset the viewer for some responsive embeds.
+- `default_page` (integer): Page number to have the document scroll to by default.
+- `default_note` (integer): ID of the note that the document should highlight by default.
+- `notes` (boolean): Show/hide notes:
+- `search` (boolean): Hide or show search form.
+- `sidebar` (boolean): Hide or show sidebar. Defaults `false`.
+- `pdf` (boolean): Hide or show link to download original PDF.
+- `text` (boolean): Hide or show text tab.
+- `zoom` (boolean): Hide or show zoom slider.
+- `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
+
+For example, if you want to embed a document at 800px wide with no sidebar, pre-scrolled to page 3:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="800" sidebar="false" default_page="3"]
+
+## Changelog
+
+### 0.2
+* Fetch embed code via oEmbed instead of generating statically.
+* Added new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
+* Deprecated `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
+
+### 0.1
+* Initial release.
+
+## History
+
+Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
+
+## License
+
+The DocumentCloud WordPress plugin is [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@ The DocumentCloud WordPress plugin lets you embed [DocumentCloud](https://www.do
 1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
 2. Activate the plugin through the "Plugins" menu
 3. Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud
-4. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
+4. In your posts, embed documents or notes using the DocumentCloud button or the `[documentcloud]` shortcode
 
 ## Usage
 
-There are many options you can set using shortcode attributes:
+There are many options you can set using shortcode attributes. Some are specific to the type of resource you're embedding.
+
+### All resources (documents and notes):
 
 - `url` (**required**, string): Full URL of the DocumentCloud resource.
-- `container` (string): ID of element to insert the document into; if excluded, embedder will create its own container.
+- `container` (string): ID of element to insert the embed into; if excluded, embedder will create its own container.
+
+### Documents only:
+
 - `height` (integer): Height (in pixels) of the embed.
 - `width` (integer): Width (in pixels) of the embed.
 - `responsive` (boolean): Use responsive layout.
@@ -35,7 +40,14 @@ For example, if you want to embed a document at 800px wide with no sidebar, pre-
 
     [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="800" sidebar="false" default_page="3"]
 
+To embed a note, use any note-specific URL:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html#document/p1/a53674"]
+
 ## Changelog
+
+### 0.3
+* Added support for embedding notes.
 
 ### 0.2
 * Fetch embed code via oEmbed instead of generating statically.
@@ -47,7 +59,7 @@ For example, if you want to embed a document at 800px wide with no sidebar, pre-
 
 ## History
 
-Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
+Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project. Development continued by Justin Reese (@reefdog) at [DocumentCloud](https://www.documentcloud.org/).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To embed a note, use any note-specific URL:
 
 ### 0.3
 * Added support for embedding notes.
+* Default to responsive
 
 ### 0.2
 * Fetch embed code via oEmbed instead of generating statically.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ There are many options you can set using shortcode attributes. Some are specific
 ### Documents only:
 
 - `height` (integer): Height (in pixels) of the embed.
-- `width` (integer): Width (in pixels) of the embed.
-- `responsive` (boolean): Use responsive layout.
+- `width` (integer): Width (in pixels) of the embed. If used, will implicitly set `responsive="false"`.
+- `responsive` (boolean): Use responsive layout, which dynamically adjusts width to fill content area. Defaults `true`.
 - `responsive_offset` (integer): Distance (in pixels) to vertically offset the viewer for some responsive embeds.
 - `default_page` (integer): Page number to have the document scroll to by default.
 - `default_note` (integer): ID of the note that the document should highlight by default.
@@ -36,9 +36,9 @@ There are many options you can set using shortcode attributes. Some are specific
 - `zoom` (boolean): Hide or show zoom slider.
 - `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
 
-For example, if you want to embed a document at 800px wide with no sidebar, pre-scrolled to page 3:
+For example, if you want to embed a document at 800px wide, pre-scrolled to page 3:
 
-    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="800" sidebar="false" default_page="3"]
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" responsive="false" width="800" default_page="3"]
 
 To embed a note, use any note-specific URL:
 

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -124,7 +124,7 @@ class WP_DocumentCloud {
 
         // Either the `url` or `id` attributes are required, but `id` 
         // is only supported for backwards compatibility. If it's used,
-        // we force this to embed a document. I.e., it can't be used 
+        // we force this to embed a document. I.e., `id` can't be used 
         // for embedding notes, pages, or other non-document resources.
         if (!$atts['url']) {
             if (!$atts['id']) {
@@ -205,7 +205,7 @@ class WP_DocumentCloud {
             <?php do_settings_sections('documentcloud'); ?>
             
             <p><input class="button-primary" name="Submit" type="submit" value="<?php esc_attr_e('Save Changes'); ?>" /></p>
-            </form>
+        </form>
         <?php
     }
     

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -30,6 +30,7 @@ class WP_DocumentCloud {
     const CACHING_ENABLED          = false,
           DEFAULT_EMBED_HEIGHT     = 620,
           DEFAULT_EMBED_WIDTH      = 600,
+          DEFAULT_EMBED_FULL_WIDTH = 940,
           OEMBED_PROVIDER          = 'https://www.documentcloud.org/api/oembed.{format}',
           OEMBED_RESOURCE_DOMAIN   = 'www.documentcloud.org';
     
@@ -91,6 +92,7 @@ class WP_DocumentCloud {
             //  4. `WP_DocumentCloud::DEFAULT_EMBED_WIDTH`
             'maxheight'         => intval(get_option('documentcloud_default_height', WP_DocumentCloud::DEFAULT_EMBED_HEIGHT)),
             'maxwidth'          => intval(get_option('documentcloud_default_width',  WP_DocumentCloud::DEFAULT_EMBED_WIDTH)),
+            'format'            => 'normal',
             'sidebar'           => 'false',
             'text'              => 'true',
             'pdf'               => 'true',
@@ -100,6 +102,7 @@ class WP_DocumentCloud {
     function add_dc_arguments($provider, $url, $args) {
         foreach ($args as $key => $value) {
             switch ($key) {
+                case 'format':
                 case 'height':
                 case 'width':
                 case 'discover':
@@ -142,6 +145,16 @@ class WP_DocumentCloud {
             $filtered_atts['maxwidth'] = $atts['width'];
         }
 
+        // If the format is set to wide, it blows away all other width 
+        // settings.
+        if ($filtered_atts['format'] == 'wide') {
+            $filtered_atts['maxwidth'] = get_option('documentcloud_full_width', DEFAULT_EMBED_FULL_WIDTH);
+        }
+        
+        // For the benefit of some templates
+        global $post;
+        $is_wide = intval($filtered_atts['maxwidth']) > $default_atts['maxwidth'];
+
         if (WP_DocumentCloud::CACHING_ENABLED) {
             // This lets WordPress cache the result of the oEmbed call.
             // Thanks to http://bit.ly/1HykA0U for this pattern.
@@ -153,7 +166,7 @@ class WP_DocumentCloud {
 
     }
 
-    // TinyMCE and settings page
+    // Setup TinyMCE shortcode button
 
     function register_tinymce_filters() {
         add_filter('mce_external_plugins', 

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -27,7 +27,7 @@
 
 class WP_DocumentCloud {
 
-    const CACHING_ENABLED          = false,
+    const CACHING_ENABLED          = true,
           DEFAULT_EMBED_FULL_WIDTH = 940,
           OEMBED_RESOURCE_DOMAIN   = 'www.documentcloud.org',
           OEMBED_PROVIDER          = 'https://www.documentcloud.org/api/oembed.{format}',
@@ -46,9 +46,6 @@ class WP_DocumentCloud {
         add_action('admin_menu', array(&$this, 'add_options_page'));
         add_action('admin_init', array(&$this, 'settings_init'));
 
-        // Register [documentcloud] shortcode using old embed method
-        // add_shortcode('documentcloud', array(&$this, 'embed_shortcode'));
-        
         // Store metadata upon post save
         add_action('save_post', array(&$this, 'save'));
     }

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -3,7 +3,7 @@
  * Plugin Name: DocumentCloud
  * Plugin URI: https://www.documentcloud.org/
  * Description: Embed DocumentCloud resources in WordPress content.
- * Version: 0.2
+ * Version: 0.3
  * Authors: Chris Amico, Justin Reese
  * License: GPLv2
 ***/

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -80,7 +80,7 @@ class WP_DocumentCloud {
             'default_note'      => null,
             'zoom'              => null,
             'search'            => null,
-            'responsive'        => 'true',
+            'responsive'        => null,
             // The following defaults match the existing plugin, except 
             // `height/width` are prefixed `max*` per the oEmbed spec.
             // You can still use `height/width` for backwards

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -64,7 +64,7 @@ class WP_DocumentCloud {
         to uncomment the next line to let WordPress connect to local
         domains.
     */
-        // add_filter( 'http_request_host_is_external', '__return_true');
+        add_filter( 'http_request_host_is_external', '__return_true');
 
         wp_oembed_add_provider("http://"  . WP_DocumentCloud::OEMBED_RESOURCE_DOMAIN . "/documents/*",  WP_DocumentCloud::OEMBED_PROVIDER);
         wp_oembed_add_provider("https://" . WP_DocumentCloud::OEMBED_RESOURCE_DOMAIN . "/documents/*",  WP_DocumentCloud::OEMBED_PROVIDER);
@@ -174,7 +174,7 @@ class WP_DocumentCloud {
             // Notes and note variants
             '{' . WP_DocumentCloud::DOCUMENT_PATTERN . '/annotations/(?P<note_id>[0-9]+)\.(html|js)$}',
             '{' . WP_DocumentCloud::DOCUMENT_PATTERN . '.html#document/p([0-9]+)/a(?P<note_id>[0-9]+)$}',
-            '{' . WP_DocumentCloud::DOCUMENT_PATTERN . '.html#annotations/a(?P<note_id>[0-9]+)$}',
+            '{' . WP_DocumentCloud::DOCUMENT_PATTERN . '.html#annotation/a(?P<note_id>[0-9]+)$}',
         );
 
         $elements = array();

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -330,6 +330,9 @@ class WP_DocumentCloud {
                 if (isset($atts['url'])) {
                     $elements = $this->parse_dc_url($atts['url']);
                     $meta_key = $elements['document_slug'];
+                    if ($elements['note_id']) {
+                        $meta_key .= "-{$elements['note_id']}";
+                    }
                 } else if (isset($atts['id'])) {
                     $meta_key = $atts['id'];
                 }

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -163,6 +163,15 @@ class WP_DocumentCloud {
         if (isset($atts['width'])) {
             $filtered_atts['maxwidth'] = $atts['width'];
         }
+        
+        // `responsive` defaults true, but our responsive layout 
+        // ignores width declarations. If a user indicates a width and 
+        // hasn't otherwise specifically indicated `responsive='true'`, 
+        // it's safe to assume they expect us to respect the width, so 
+        // we disable the responsive flag.
+        if ((isset($atts['width']) || isset($atts['maxwidth'])) && (string) $atts['responsive'] != 'true') {
+            $filtered_atts['responsive'] = 'false';
+        }
 
         // If the format is set to wide, it blows away all other width 
         // settings.
@@ -241,6 +250,8 @@ class WP_DocumentCloud {
     function render_options_page() { ?>
         <h2>DocumentCloud Options</h2>
         <form action="options.php" method="post">
+
+            <p>Any widths set here will only take effect if you set <code>responsive="false"</code> on an embed.</p>
             
             <?php settings_fields('documentcloud'); ?>
             <?php do_settings_sections('documentcloud'); ?>

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -40,7 +40,7 @@ class WP_DocumentCloud {
         add_filter('oembed_fetch_url', array(&$this, 'add_dc_arguments'), 10, 3);
 
         // Setup TinyMCE shortcode-generation plugin
-        add_action('init', array(&$this, 'register_tinymce_filters'));
+        // add_action('init', array(&$this, 'register_tinymce_filters'));
 
         // Setup admin settings
         add_action('admin_menu', array(&$this, 'add_options_page'));

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -3,7 +3,7 @@
  * Plugin Name: DocumentCloud
  * Plugin URI: https://www.documentcloud.org/
  * Description: Embed DocumentCloud resources in WordPress content.
- * Version: 0.1.1
+ * Version: 0.1.2
  * Authors: Chris Amico, Justin Reese
  * License: GPLv2
 ***/
@@ -29,17 +29,36 @@ class WP_DocumentCloud {
     
     function __construct() {
 
+        // Register us as an oEmbed provider
+        add_action('init', array(&$this, 'register_dc_oembed_provider'));
+        // Register [documentcloud] shortcode using old embed method
         add_shortcode('documentcloud', array(&$this, 'embed_shortcode'));
         
+        // Setup TinyMCE shortcode-generation plugin
         add_action('init', array(&$this, 'register_tinymce_filters'));
-        
+
+        // Process shortcodes and add admin settings
         add_action('save_post', array(&$this, 'save'));
-        
         add_action('admin_menu', array(&$this, 'add_options_page'));
-        
         add_action('admin_init', array(&$this, 'settings_init'));
     }
     
+    function register_dc_oembed_provider() {
+    /*
+        Hello developer. If you wish to test this plugin against your
+        local installation of DocumentCloud (with its own testing
+        domain), uncomment-out the next three lines and replace
+        `[your_domain]` with, uh, your domain. You'll also want to keep
+        the provider HTTP unless cURL can happily access your domain via
+        HTTPS. Please remember not to commit these back to the repo.
+    */
+        // add_filter( 'http_request_host_is_external', '__return_true' );
+        // wp_oembed_add_provider('http://[your_domain]/documents/*','http://[your_domain]/api/oembed.{format}');
+        // wp_oembed_add_provider('https://[your_domain]/documents/*','http://[your_domain]/api/oembed.{format}');
+
+        wp_oembed_add_provider('https://www.documentcloud.org/documents/*', 'https://www.documentcloud.org/api/oembed.{format}');
+    }
+
     function register_tinymce_filters() {
         add_filter('mce_external_plugins', 
             array(&$this, 'add_tinymce_plugin')

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -32,7 +32,7 @@ class WP_DocumentCloud {
           DEFAULT_EMBED_WIDTH      = 600,
           DEFAULT_EMBED_FULL_WIDTH = 940,
           OEMBED_RESOURCE_DOMAIN   = 'www.documentcloud.org',
-          OEMBED_PROVIDER          = 'http://www.documentcloud.org/api/oembed.{format}',
+          OEMBED_PROVIDER          = 'https://www.documentcloud.org/api/oembed.{format}',
           DOCUMENT_PATTERN         = '^(?P<protocol>https?)://www\.documentcloud\.org/documents/(?P<document_id>[0-9]+-[a-z0-9-]+)';
     
     function __construct() {

--- a/documentcloud.php
+++ b/documentcloud.php
@@ -81,7 +81,7 @@ class WP_DocumentCloud {
             'default_note'      => null,
             'zoom'              => null,
             'search'            => null,
-            'responsive'        => null,
+            'responsive'        => 'true',
             // The following defaults match the existing plugin, except 
             // `height/width` are prefixed `max*` per the oEmbed spec.
             // You can still use `height/width` for backwards

--- a/js/window.php
+++ b/js/window.php
@@ -6,6 +6,9 @@ if (isset($_SERVER['HTTPS'])) {
 }
 $SITEURL .= $_SERVER[ 'HTTP_HOST' ] or $_SERVER[ 'SERVER_NAME' ];
 $SITEURL .= $_GET[ 'wpbase' ];
+if (substr($SITEURL, -1) != '/') {
+    $SITEURL .= '/';
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Embed DocumentCloud resources in WordPress content.
 
 == Description ==
 
-[DocumentCloud](https://www.documentcloud.org/) is a free service allowing journalists to analyze, annotate and publish documents, funded by the Knight Foundation. Initial development of this plugin supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
+[DocumentCloud](https://www.documentcloud.org/) is a service that allows journalists to analyze, annotate and publish documents, hosted by Investigative Reporters & Editors. Initial development of this plugin supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
 
 DocumentCloud's normal embed code looks like this:
 
@@ -43,5 +43,4 @@ This will use default height and width settings, which you can update in the Wor
 
 1. Upload the documentcloud directory to `wp-content/plugins/documentcloud`
 2. Activate the plugin
-3. In your posts, add documents using the DocumentCloud button, or the `[documentcloud]` shortcode.
-
+3. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,11 @@
 === DocumentCloud ===
 Contributors: chrisamico, reefdog
-Tags: documentcloud, documents
+Tags: documentcloud, documents, journalism, reporting, research
 Requires at least: 3.2
-Tested up to: 3.9.1
+Tested up to: 4.1.1
 Stable tag: trunk
+License: GPLv2
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Embed DocumentCloud resources in WordPress content.
 
@@ -11,36 +13,49 @@ Embed DocumentCloud resources in WordPress content.
 
 [DocumentCloud](https://www.documentcloud.org/) is a service that allows journalists to analyze, annotate and publish documents, hosted by Investigative Reporters & Editors. Initial development of this plugin supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
 
-DocumentCloud's normal embed code looks like this:
-
-    <div id="DV-viewer-265231-11-07-2011-letter-to-idaho-congressional" class="DV-container"></div>
-    <script src="http://s3.documentcloud.org/viewer/loader.js"></script>
-    <script>
-     DV.load('http://www.documentcloud.org/documents/265231-11-07-2011-letter-to-idaho-congressional.js', {
-        width: 600,
-        height: 450,
-        sidebar: false,
-        container: "#DV-viewer-265231-11-07-2011-letter-to-idaho-congressional"
-      });
-    </script>
-    
-That works great as long as you edit in HTML mode. Switch to the visual editor, and your container `div` disappears and your JavaScript is broken.
-
-To get around this, use this short code:
-
-    [documentcloud id="265231-11-07-2011-letter-to-idaho-congressional"]
-    
-Or use the URL from DocumentCloud:
+This plugin allows you embed DocumentCloud documents using a custom shortcode:
 
     [documentcloud url="http://www.documentcloud.org/documents/265231-11-07-2011-letter-to-idaho-congressional.html"]
 
-This will use default height and width settings, which you can update in the WordPress admin. To override defaults on a specific document, pass them into the shortcode:
+When you save, WordPress fetches and stores the actual embed code HTML from the DocumentCloud servers using oEmbed. You can freely toggle between visual and HTML mode without mangling embed code, and your embed will always be up to date with the latest embed code.
 
-    [documentcloud id="265231-11-07-2011-letter-to-idaho-congressional" width="400" height="500" sidebar="true"]
+By default, the embed will be 600px wide and 620px tall. You can set your own defaults in Settings > DocumentCloud, or override the defaults on individual embeds using these attributes:
 
+    [documentcloud url="http://www.documentcloud.org/documents/265231-11-07-2011-letter-to-idaho-congressional.html" width="400" height="500"]
+
+Here's the full list of embed options you can pass via shortcode attributes:
+
+- `url` (**required**, string): Full URL of the DocumentCloud resource.
+- `container` (string): ID of element to insert the document into; if excluded, embedder will create its own container.
+- `height` (integer): Height (in pixels) of the embed.
+- `width` (integer): Width (in pixels) of the embed.
+- `responsive` (boolean): Use responsive layout.
+- `responsive_offset` (integer): Distance (in pixels) to vertically offset the viewer for some responsive embeds.
+- `default_page` (integer): Page number to have the document scroll to by default.
+- `default_note` (integer): ID of the note that the document should highlight by default.
+- `notes` (boolean): Show/hide notes:
+- `search` (boolean): Hide or show search form.
+- `sidebar` (boolean): Hide or show sidebar. Defaults `false`.
+- `pdf` (boolean): Hide or show link to download original PDF.
+- `text` (boolean): Hide or show text tab.
+- `zoom` (boolean): Hide or show zoom slider.
+- `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
+
+You can read more about publishing and embedding DocumentCloud resources on https://www.documentcloud.org/help/publishing.
 
 == Installation ==
 
-1. Upload the documentcloud directory to `wp-content/plugins/documentcloud`
-2. Activate the plugin
-3. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
+1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
+2. Activate the plugin through the "Plugins" menu
+3. Optionally set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes)
+4. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
+
+== Changelog ==
+
+= 0.2 =
+* Fetch embed code via oEmbed instead of generating statically.
+* Added new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
+* Deprecated `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
+
+= 0.1 =
+* Initial release.

--- a/readme.txt
+++ b/readme.txt
@@ -19,11 +19,15 @@ This plugin allows you embed DocumentCloud resources using a custom shortcode:
 
 When you save, WordPress fetches and stores the actual embed code HTML from the DocumentCloud servers using oEmbed. You can freely toggle between visual and HTML mode without mangling embed code, and your embed will always be up to date with the latest embed code.
 
-By default, documents will be 600px wide and 620px tall. You can set your own defaults in Settings > DocumentCloud, or override the defaults on individual embeds using these attributes:
+By default, documents will have a responsive width (it will narrow and widen as necessary to fill available content area) and use the theme's default height. If you want to override this, you can either set `responsive="false"` or explicitly set a `width`:
 
-    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="400" height="500"]
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="600"]
 
-You can also forego width/height and have the document fill the horizontal width of its container by using the `responsive="true"` shortcode. (Notes ignore width/height and always act responsively.)
+You can set your own defaults in Settings > DocumentCloud, but default widths will be ignored unless `responsive` is disabled:
+
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" responsive="false"]
+
+Notes ignore `width/height` and always act responsively.
 
 Here's the full list of embed options you can pass via shortcode attributes.
 
@@ -35,16 +39,16 @@ All resources (documents and notes):
 Documents only:
 
 - `height` (integer): Height (in pixels) of the embed.
-- `width` (integer): Width (in pixels) of the embed.
-- `responsive` (boolean): Use responsive layout.
+- `width` (integer): Width (in pixels) of the embed. If used, will implicitly set `responsive="false"`.
+- `responsive` (boolean): Use responsive layout, which dynamically adjusts width to fill content area. Defaults `true`.
 - `responsive_offset` (integer): Distance (in pixels) to vertically offset the viewer for some responsive embeds.
 - `default_page` (integer): Page number to have the document scroll to by default.
 - `default_note` (integer): ID of the note that the document should highlight by default.
 - `notes` (boolean): Show/hide notes:
 - `search` (boolean): Hide or show search form.
 - `sidebar` (boolean): Hide or show sidebar. Defaults `false`.
-- `pdf` (boolean): Hide or show link to download original PDF.
-- `text` (boolean): Hide or show text tab.
+- `pdf` (boolean): Hide or show link to download original PDF. Defaults `true`.
+- `text` (boolean): Hide or show text tab. Defaults `true`.
 - `zoom` (boolean): Hide or show zoom slider.
 - `format` (string): Indicate to the theme that this is a wide asset by setting this to `wide`. Defaults `normal`.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: chrisamico, reefdog
 Tags: documentcloud, documents, journalism, reporting, research
 Requires at least: 3.2
-Tested up to: 4.1.1
+Tested up to: 4.2.1
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -15,13 +15,13 @@ Embed DocumentCloud resources in WordPress content.
 
 This plugin allows you embed DocumentCloud documents using a custom shortcode:
 
-    [documentcloud url="http://www.documentcloud.org/documents/265231-11-07-2011-letter-to-idaho-congressional.html"]
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html"]
 
 When you save, WordPress fetches and stores the actual embed code HTML from the DocumentCloud servers using oEmbed. You can freely toggle between visual and HTML mode without mangling embed code, and your embed will always be up to date with the latest embed code.
 
 By default, the embed will be 600px wide and 620px tall. You can set your own defaults in Settings > DocumentCloud, or override the defaults on individual embeds using these attributes:
 
-    [documentcloud url="http://www.documentcloud.org/documents/265231-11-07-2011-letter-to-idaho-congressional.html" width="400" height="500"]
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="400" height="500"]
 
 Here's the full list of embed options you can pass via shortcode attributes:
 
@@ -47,7 +47,7 @@ You can read more about publishing and embedding DocumentCloud resources on http
 
 1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
 2. Activate the plugin through the "Plugins" menu
-3. Optionally set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes)
+3. Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud
 4. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
 
 == Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -59,3 +59,8 @@ You can read more about publishing and embedding DocumentCloud resources on http
 
 = 0.1 =
 * Initial release.
+
+== Upgrade Notice ==
+
+= 0.2 =
+Adds oEmbed support for future-proofing embed codes. Provides additional embed options like `default_page`.

--- a/readme.txt
+++ b/readme.txt
@@ -13,20 +13,27 @@ Embed DocumentCloud resources in WordPress content.
 
 [DocumentCloud](https://www.documentcloud.org/) is a service that allows journalists to analyze, annotate and publish documents, hosted by Investigative Reporters & Editors. Initial development of this plugin supported by [NPR](http://www.npr.org) as part of [StateImpact](http://stateimpact.npr.org) project.
 
-This plugin allows you embed DocumentCloud documents using a custom shortcode:
+This plugin allows you embed DocumentCloud resources using a custom shortcode:
 
     [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html"]
 
 When you save, WordPress fetches and stores the actual embed code HTML from the DocumentCloud servers using oEmbed. You can freely toggle between visual and HTML mode without mangling embed code, and your embed will always be up to date with the latest embed code.
 
-By default, the embed will be 600px wide and 620px tall. You can set your own defaults in Settings > DocumentCloud, or override the defaults on individual embeds using these attributes:
+By default, documents will be 600px wide and 620px tall. You can set your own defaults in Settings > DocumentCloud, or override the defaults on individual embeds using these attributes:
 
     [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" width="400" height="500"]
 
-Here's the full list of embed options you can pass via shortcode attributes:
+You can also forego width/height and have the document fill the horizontal width of its container by using the `responsive="true"` shortcode. (Notes ignore width/height and always act responsively.)
+
+Here's the full list of embed options you can pass via shortcode attributes.
+
+All resources (documents and notes):
 
 - `url` (**required**, string): Full URL of the DocumentCloud resource.
-- `container` (string): ID of element to insert the document into; if excluded, embedder will create its own container.
+- `container` (string): ID of element to insert the embed into; if excluded, embedder will create its own container.
+
+Documents only:
+
 - `height` (integer): Height (in pixels) of the embed.
 - `width` (integer): Width (in pixels) of the embed.
 - `responsive` (boolean): Use responsive layout.
@@ -52,6 +59,9 @@ You can read more about publishing and embedding DocumentCloud resources on http
 
 == Changelog ==
 
+= 0.3 =
+* Added support for embedding notes.
+
 = 0.2 =
 * Fetch embed code via oEmbed instead of generating statically.
 * Added new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
@@ -61,6 +71,9 @@ You can read more about publishing and embedding DocumentCloud resources on http
 * Initial release.
 
 == Upgrade Notice ==
+
+= 0.3 =
+Adds support for embedding notes.
 
 = 0.2 =
 Adds oEmbed support for future-proofing embed codes. Provides additional embed options like `default_page`.

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,7 @@ You can read more about publishing and embedding DocumentCloud resources on http
 
 = 0.3 =
 * Added support for embedding notes.
+* Default to responsive
 
 = 0.2 =
 * Fetch embed code via oEmbed instead of generating statically.

--- a/readme.txt
+++ b/readme.txt
@@ -27,16 +27,18 @@ You can set your own defaults in Settings > DocumentCloud, but default widths wi
 
     [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html" responsive="false"]
 
-Notes ignore `width/height` and always act responsively.
+To embed a note, just use any note-specific URL. Notes ignore `width/height` and always act responsively:
 
-Here's the full list of embed options you can pass via shortcode attributes.
+    [documentcloud url="https://www.documentcloud.org/documents/282753-lefler-thesis.html#document/p1/a53674"]
 
-All resources (documents and notes):
+Here's the full list of embed options you can pass via shortcode attributes; some are specific to the type of resource you're embedding.
+
+**All resources (documents and notes):**
 
 - `url` (**required**, string): Full URL of the DocumentCloud resource.
 - `container` (string): ID of element to insert the embed into; if excluded, embedder will create its own container.
 
-Documents only:
+**Documents only:**
 
 - `height` (integer): Height (in pixels) of the embed.
 - `width` (integer): Width (in pixels) of the embed. If used, will implicitly set `responsive="false"`.
@@ -58,19 +60,20 @@ You can read more about publishing and embedding DocumentCloud resources on http
 
 1. Upload the contents of the plugin to `wp-content/plugins/documentcloud`
 2. Activate the plugin through the "Plugins" menu
-3. Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud
-4. In your posts, add documents using the DocumentCloud button or the `[documentcloud]` shortcode
+3. In your posts, embed documents or notes using the DocumentCloud button or the `[documentcloud]` shortcode
+4. Optional: Set a default width/height for all DocumentCloud embeds (which can be overridden on a per-embed basis with the `height/width` attributes) at Settings > DocumentCloud. (This default width will only be used if you set `responsive="false"` on an embed.)
 
 == Changelog ==
 
 = 0.3 =
-* Added support for embedding notes.
-* Default to responsive
+* Add support for embedding notes.
+* Default to responsive.
+* Enable caching.
 
 = 0.2 =
 * Fetch embed code via oEmbed instead of generating statically.
-* Added new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
-* Deprecated `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
+* Add new options: `container`, `responsive`, `responsive_offset`, `default_page`, `default_note`, `notes`, `search`, and `zoom`.
+* Deprecate `id` attribute. It's still usable, but support may drop in the future. Use `url` instead.
 
 = 0.1 =
 * Initial release.
@@ -78,7 +81,7 @@ You can read more about publishing and embedding DocumentCloud resources on http
 == Upgrade Notice ==
 
 = 0.3 =
-Adds support for embedding notes.
+Adds support for embedding notes and enables caching.
 
 = 0.2 =
 Adds oEmbed support for future-proofing embed codes. Provides additional embed options like `default_page`.


### PR DESCRIPTION
This is a proposal to replace Navis-DocumentCloud's existing embed code construction by deferring to DocumentCloud's oEmbed endpoint.

This release would include deploying a new plugin named Wordpress-DocumentCloud to supersede Navis-DocumentCloud.